### PR TITLE
Specify copyright holder in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = CPAN-Mini-Webserver
 author  = Leon Brocard <acme@astray.com>
 author  = Christian Walde <walde.christian@googlemail.com>
 license = Perl_5
-;copyright_holder = Christian Walde
+copyright_holder = Christian Walde
 ;copyright_year   = 2011
 
 ; version provider


### PR DESCRIPTION
This is required for e.g. `dzil test` to run.  If the `copyright_holder` variable isn't set, then `dzil` commands fail with the error message: `no copyright holder specified`.

This pull request is submitted in the hope that it is useful.  If you wish for it to be changed in any way, please let me know and I'll update and resubmit as necessary.