### PR TITLE
Add authordep for DAGOLDEN Pod::Weaver plugin bundle

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ exclude_match = ^\.git
 [OurPkgVersion]     ; add $VERSION = ... to all files
 [PodWeaver]         ; generate Pod
 config_plugin = @DAGOLDEN ; my own plugin allows Pod::WikiDoc
+; authordep Pod::Weaver::PluginBundle::DAGOLDEN
 
 ; generated files
 [License]                   ; boilerplate license


### PR DESCRIPTION
This plugin bundle is required for the `dzil listdeps` step to work
correctly on a fresh Perl installation; indirect prereqs (such as is
often the case with Pod::Weaver plugins) need to be added to the
`dist.ini` as in this patch so that they can be found by `dzil
authordeps` and hence can be installed prior to installing the remaining
dependencies.

See also the section on declaring author prereqs in the [Dist::Zilla prereqs docs](http://dzil.org/tutorial/prereq.html).

This patch is submitted in the hope that it is useful.  If you want anything changed, please just let me know and I'll update and resubmit as necessary.