### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,13 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cpanm --notest Dist::Zilla || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+  - dzil authordeps --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+  - dzil listdeps --author --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - dzil test --author --release


### PR DESCRIPTION
AppVeyor is a continuous integration and build service which is free for open source projects and allows projects to be built and tested on Windows.  This patch adds an initial configuration for this service.  Note that in order for the dependencies to install correctly and for all the tests to run, pull requests #4 and #5 (or variants thereof) need to be applied before this configuration can work correctly "out of the box".

If you need anything updated or changed, just let me know and I'll fix and resubmit as appropriate.