### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
Travis-CI is a continuous integration and build service which is free for open source projects.  This patch adds an initial configuration allowing pushes and pull requests to automatically run the dist's test suite for several Perl versions.  In order for this configuration to work as submitted, pull requests #4 and #5 (or variants thereof) need to be applied first; it is namely necessary to set the copyright holder field and to install the DAGOLDEN Pod::Weaver plugin bundle as part of the dependency installation step.

If you want anything updated or changed in this patch, please just let me know and I'll fix and resubmit as necessary.